### PR TITLE
lesson: 13강 캐시 비활성화

### DIFF
--- a/db.json
+++ b/db.json
@@ -19,6 +19,21 @@
       "title": "react",
       "body": "react is ...",
       "id": 4
+    },
+    {
+      "title": "a",
+      "body": "a",
+      "id": 5
+    },
+    {
+      "title": "b",
+      "body": "b",
+      "id": 6
+    },
+    {
+      "title": "c",
+      "body": "c",
+      "id": 7
     }
   ],
   "posts": [

--- a/src/app/create/page.js
+++ b/src/app/create/page.js
@@ -21,6 +21,7 @@ export default function Create() {
                 .then(result => {
                     console.log(result)
                     const lastid = result.id;
+                    router.refresh();
                     router.push(`/read/${lastid}`);
                 });
         }}>

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -7,7 +7,7 @@ export const metadata = {
 };
 
 export default async function RootLayout({ children }) {
-  const response = await fetch('http://localhost:9999/topics');
+  const response = await fetch('http://localhost:9999/topics', {cache: "no-store"}); // 또는 2번쨰 인자값으로 {next:{revaliate:0}}
   const topics = await response.json();
   return (
     <html>


### PR DESCRIPTION
- close #23 
- 테스트 완료
- router.refresh()는 서버 컴포넌트를 강제로 다시 랜더링 하도록 하는 기능입니다. 
- 이 함수를 호출하지 않으면 서버의 데이터를 변경했음에도 서버 컴포넌트가 그대로 입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 토픽 데이터가 항상 최신 상태로 유지되도록 캐싱 비활성화 적용

* **개선사항**
  * 새 항목 생성 후 목록에 즉시 반영되도록 새로고침 기능 추가

* **기타**
  * 샘플 데이터 3개 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->